### PR TITLE
a50-common: Remove audio a2dp from common.mk

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -26,7 +26,6 @@ PRODUCT_PACKAGES += \
     android.hardware.audio.service \
     android.hardware.bluetooth.audio@2.0-impl:32 \
     android.hardware.soundtrigger@2.0-impl:32 \
-    audio.a2dp.default \
     audio.bluetooth.default \
     audio.r_submix.default \
     audio.usb.default \


### PR DESCRIPTION
Based on https://github.com/Evolution-X-Devices/device_xiaomi_raphael/commit/bea8eadf5d64558ecab76133ed0f2909b33bba3d.